### PR TITLE
chore: test bundler module resolution

### DIFF
--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,0 +1,2 @@
+# enable TypeScript bundler module resolution - https://www.typescriptlang.org/docs/handbook/modules/reference.html#bundler
+typescript.tsConfig.compilerOptions.moduleResolution=Bundler


### PR DESCRIPTION
This is a 'canary' pull request. It aims to ensure that the ecosystem is ready for a shift in the default Nuxt TypeScript module resolution from 'Legacy' to 'Bundler': https://github.com/nuxt/nuxt/pull/24837. You'll need to run your build + type checking tests to verify that things still work; I'm hoping that CI will do that for us so we get an immediate indication of whether there's anything to investigate further here.

'Bundler' module resolution is [recommended by Vue](https://github.com/vuejs/tsconfig/blob/mainz/tsconfig.json#L24-L26) and [by Vite](https://vitejs.dev/guide/performance.html#reduce-resolve-operations), but unfortunately there are still many packages that do not have the correct entries in their `package.json`.

This might include this module or packages that are _used_ by this module. You can see, for example: https://arethetypeswrong.github.io/?p=@nuxtus/nuxt-localtunnel. The initial red X for `node10` needs to be fixed in https://github.com/nuxt/module-builder; you can ignore that for now.

If there are any errors reported in CI for this PR, it would be good to fix them for the sake of any users of this module who enable the Bundler module resolution. Feel free to ping me or others on the [Nuxt Discord](https://discord.nuxtjs.org) if you need any help resolving any issues discovered by this PR - and feel free to check out https://github.com/nuxt/nuxt/pull/24837 for any feedback or comments from others affected.