### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Nuxt module for automatically running [localtunnnel](https://github.com/localt
 ## Installation
 
 ```bash
-npm install @nuxtus/nuxt-localtunnel
+npx nuxi@latest module add nuxt-localtunnel
 ```
 
 Edit your nuxt.config.ts and add the @nuxtus/nuxt-localtunnel module:


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
